### PR TITLE
fix: workaround to fix katex display on safari for markmap

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -13,7 +13,7 @@
         {{- partial "helper/external" (dict "Context" . "Namespace" "PhotoSwipe") -}}
     {{ end }}
 
-    {{ if .Site.Params.katex.enable }}
+    {{ if and (.Site.Params.katex.enable) (not .Site.Params.markmap.enable) }}
         {{- partial "helper/external" (dict "Context" . "Namespace" "KaTeX") -}}
     {{ end }}
 


### PR DESCRIPTION
fix katex display on safari for markmap, see [discussion](https://github.com/librabyte/hugo-theme-cosmos/discussions/9)